### PR TITLE
feat: add simple dex example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rayon = "1.0"
 
 [dev-dependencies]
 bencher = "0.1"
+rand = "0.7"
 
 [[bench]]
 name = "benchmark"

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ riscv/example/raw:
 	$(CC) -I./src/riscv/c/ -o ./build/riscv_c_sdk ./examples/riscv_c_sdk.c
 	$(CC) -I./src/riscv/c/ -o ./build/riscv_c_fibonacci ./examples/riscv_c_fibonacci.c
 	$(CC) -I./src/riscv/c/ -o ./build/riscv_c_simplestorage ./examples/riscv_c_simplestorage.c
+	$(CC) -I./src/riscv/c/ -o ./build/riscv_c_dex ./examples/riscv_c_dex.c
 
 riscv/example:
 	$(DOCKER_BUILD) "cd /src && make riscv/example/raw"

--- a/examples/riscv_c_dex.c
+++ b/examples/riscv_c_dex.c
@@ -1,0 +1,81 @@
+#include <string.h>
+
+#include "pvm.h"
+#include "pvm_extend.h"
+
+// typedef struct clear_record {
+//   uint8_t address[20];
+//   uint8_t asset_id[32];
+//   uint64_t amount;
+// } clear_record;
+
+int deposit(uint8_t *address, uint8_t *asset_id, uint64_t amount)
+{
+  // tranfer asset from user to contract
+  uint8_t key[52];
+  memcpy(key, address, 20);
+  memcpy(key + 20, asset_id, 32);
+  uint64_t current_amount;
+  pvm_load(key, 52, (uint8_t*)&current_amount, 8, NULL);
+  current_amount += amount;
+  pvm_save(key, 52, (uint8_t*)&current_amount, 8);
+  return 0;
+}
+
+int withdraw(uint8_t *address, uint8_t *asset_id, uint64_t amount)
+{
+  uint8_t key[52];
+  memcpy(key, address, 20);
+  memcpy(key + 20, asset_id, 32);
+  uint64_t current_amount;
+  pvm_load(key, 52, (uint8_t*)&current_amount, 8, NULL);
+  if (current_amount < amount)
+  {
+    return 1;
+  }
+  current_amount -= amount;
+  pvm_save(key, 52, (uint8_t*)&current_amount, 8);
+  // tranfer asset from  contract to user
+  return 0;
+}
+
+/**
+ * The contract receive new balance state from trade engine and reset user's balance
+ * saved in contract.
+ * 
+ * params:
+ * - clear_records_len: the length of clear_records data
+ * - clear_records: serial clear records, every record contains 60 bytes:
+ *    - 00~19: address
+ *    - 20~51: asset_id
+ *    - 52~59: amount in u64, little-endian
+ */
+int simple_clear(uint32_t *clear_records_len, uint8_t *clear_records)
+{
+  // pvm_dump_memory(clear_records, *clear_records_len * 60);
+  // pvm_dump_memory(clear_records_len, 4);
+  for (uint32_t i = 0; i < *clear_records_len; i++)
+  {
+    pvm_save(clear_records + i * 60, 52, clear_records + i * 60 + 52, 8);
+    // pvm_dump_memory(clear_records + i * 60, 60);
+  }
+  return 0;
+}
+
+int main(int argc, char *argv[])
+{
+  if (argc == 1)
+  {
+    return 0;
+  }
+
+  if (strcmp(argv[1], "clear") == 0)
+  {
+    if (argc != 4)
+    {
+      return 1;
+    }
+    return simple_clear((uint32_t *)argv[2], (uint8_t *)argv[3]);
+  }
+  return 0;
+}

--- a/examples/riscv_c_dex.rs
+++ b/examples/riscv_c_dex.rs
@@ -1,0 +1,53 @@
+use std::fs;
+use std::time::SystemTime;
+
+use ethereum_types::U256;
+use rand::prelude::*;
+
+fn main() {
+    let vm = cita_vm::FakeVM::new();
+
+    let tx = cita_vm::Transaction {
+        from: vm.account1.clone(),
+        to: None,
+        value: U256::from(0),
+        nonce: U256::from(1),
+        gas_limit: 1_000_000_000,
+        gas_price: U256::from(1),
+        input: fs::read("./build/riscv_c_dex").unwrap(),
+        itype: cita_vm::InterpreterType::RISCV,
+    };
+    let r = vm.executor.exec(cita_vm::Context::default(), tx).unwrap();
+    println!("{:?}", r);
+    let contract_address = match r {
+        cita_vm::InterpreterResult::Create(_, _, _, a) => a,
+        _ => unreachable!(),
+    };
+
+    let test_clear_records_num: u32 = 3000;
+    let one_struct_bytes = 60;
+    let byte_num = test_clear_records_num * one_struct_bytes;
+    let mut rng = rand::thread_rng();
+    let clear_params = test_clear_records_num.to_le_bytes().to_vec();
+    let data = (0..byte_num).map(|_| rng.gen::<u8>()).collect::<Vec<_>>();
+
+    let tx = cita_vm::Transaction {
+        from: vm.account1.clone(),
+        to: Some(contract_address),
+        value: U256::from(0),
+        nonce: U256::from(2),
+        gas_limit: 1_000_000_000,
+        gas_price: U256::from(1),
+        input: cita_vm::riscv::combine_parameters(vec!["clear".as_bytes().to_owned(), clear_params, data]),
+        itype: cita_vm::InterpreterType::RISCV,
+    };
+    let now = SystemTime::now();
+    let r = vm.executor.exec(cita_vm::Context::default(), tx).unwrap();
+    let d = now.elapsed().unwrap().as_millis();
+    println!("{:?}", r);
+    println!(
+        "Finish clearing {} records in {:?}s",
+        test_clear_records_num,
+        d as f64 / 1000.0,
+    );
+}

--- a/src/riscv/c/pvm_extend.h
+++ b/src/riscv/c/pvm_extend.h
@@ -3,41 +3,59 @@
 
 #include "pvm.h"
 
+const char *HEX_CHARS = "0123456789abcdef";
 
-int pvm_hex2bin(char *s, char *buf)
+uint8_t hex2int(char c)
 {
-    int i,n = 0;
-    for(i = 0; s[i]; i += 2) {
-        int c = tolower(s[i]);
-        if(c >= 'a' && c <= 'f')
-            buf[n] = c - 'a' + 10;
-        else buf[n] = c - '0';
-        if(s[i + 1] >= 'a' && s[i + 1] <= 'f')
-            buf[n] = (buf[n] << 4) | (s[i + 1] - 'a' + 10);
-        else buf[n] = (buf[n] << 4) | (s[i + 1] - '0');
-        ++n;
-    }
-    return n;
+  if (c >= 'a' && c <= 'f')
+  {
+    return c - 'a';
+  }
+  else if (c >= 'A' && c <= 'F')
+  {
+    return c - 'A';
+  }
+  else
+  {
+    return c - '0';
+  }
 }
 
-int pvm_bin2hex(uint8_t *bin, uint8_t len, char* out)
+int pvm_hex2bin(const char *hex, int hex_length, uint8_t *bin)
 {
-	uint8_t  i;
-	for (i=0; i<len; i++) {
-		out[i*2]   = "0123456789abcdef"[bin[i] >> 4];
-		out[i*2+1] = "0123456789abcdef"[bin[i] & 0x0F];
-	}
-	out[len*2] = '\0';
-    return 0;
+  for (int i = 0; i < hex_length; i += 2)
+  {
+    bin[i / 2] = hex2int(hex[i]) >> 4 + hex2int(hex[i + 1]);
+  }
+  return 0;
+}
+
+int pvm_bin2hex(uint8_t *bin, int bin_len, char *hex)
+{
+  for (int i = 0; i < bin_len; i++)
+  {
+    hex[i * 2] = HEX_CHARS[bin[i] >> 4];
+    hex[i * 2 + 1] = HEX_CHARS[bin[i] & 0x0F];
+  }
+  hex[bin_len * 2] = '\0';
+  return 0;
+}
+
+int pvm_dump_memory(uintptr_t addr, int length)
+{
+  char *hex = (char *)malloc(length * 2 + 1);
+  pvm_bin2hex((u_int8_t *)addr, length, hex);
+  pvm_debug(hex);
+  return 0;
 }
 
 int pvm_ret_str(const char *s)
 {
-    uint8_t *buffer = (uint8_t *)s;
-    return pvm_ret(&buffer[0], strlen(buffer));
+  uint8_t *buffer = (uint8_t *)s;
+  return pvm_ret(&buffer[0], strlen(buffer));
 }
 
 int pvm_ret_u64(uint64_t n)
 {
-    return pvm_ret((uint8_t*)&n, 8);
+  return pvm_ret((uint8_t *)&n, 8);
 }

--- a/src/riscv/utils.rs
+++ b/src/riscv/utils.rs
@@ -1,9 +1,9 @@
-use std::u16;
+use std::u32;
 
 pub fn combine_parameters(args: Vec<Vec<u8>>) -> Vec<u8> {
     let mut r: Vec<u8> = Vec::new();
     for e in &args {
-        let l = e.len() as u16;
+        let l = e.len() as u32;
         let l_byte = l.to_be_bytes();
         r.append(&mut l_byte.to_vec());
         r.extend(e);
@@ -16,14 +16,14 @@ pub fn cutting_parameters(args: Vec<u8>) -> Vec<Vec<u8>> {
     let mut i = 0;
     let mut r: Vec<Vec<u8>> = Vec::new();
     loop {
-        if i + 2 > l {
+        if i + 4 > l {
             return r;
         }
-        let mut n_byte = [0x00u8; 2];
-        n_byte.copy_from_slice(&args[i..i + 2]);
-        i += 2;
+        let mut n_byte = [0x00u8; 4];
+        n_byte.copy_from_slice(&args[i..i + 4]);
+        i += 4;
 
-        let n = u16::from_be_bytes(n_byte) as usize;
+        let n = u32::from_be_bytes(n_byte) as usize;
         if i + n as usize > l {
             return r;
         }


### PR DESCRIPTION
usage:

```
$ make riscv/example && cargo run --release --example riscv_c_dex

    Finished release [optimized] target(s) in 0.14s
     Running `target/release/examples/riscv_c_dex`
Create([], 999376728, [], 0x535b3d7a252fa034ed71f0c53ec0c6f784cb64e1)
Normal([], 985552612, [])
Finish clearing 3000 records in 0.357s
```
